### PR TITLE
[Core] Write logic to generate monochromatic color palette based on uploaded image

### DIFF
--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -1,10 +1,8 @@
 import sys
-import os
 import colorsys
 from cpm_app.cli_flow.utils import get_color_format, get_user_file, get_color_scheme
-from PIL import Image, ImageDraw
 
-from cpm_app.utils import get_color_from_img, make_monochromatic_color_palette
+from cpm_app.utils import get_color_from_img, make_monochromatic_color_palette, draw_color_palette
 
 
 def interactive_flow():
@@ -16,28 +14,21 @@ def interactive_flow():
         color_scheme = get_color_scheme(color_schemes)
         color_format = get_color_format(color_formats)
         main_color = get_color_from_img(file_name)
-        mono_cp = make_monochromatic_color_palette(main_color, color_format)
-        # TODO: Write function to generate color palette
-            # generate_color_palette(cs: str, cf: str)
+        mono_cps = make_monochromatic_color_palette(main_color, color_format)
 
-        # TODO: Pretty print this in a nice user friendly format
+        # TODO: Pretty print this in a nice format
         print("\n")
         print(f"File: {file_name}")
         print(f"Color Scheme: {color_scheme}")
         print(f"Color Format: {color_format}")
+        # TODO: Fix main color and print HLS or RGB depending on user format input...geez!
         print(f"Main Color: {colorsys.hls_to_rgb(main_color[0], main_color[1], main_color[2])}")
-        print(f"Color palette: {mono_cp}")
-
-        bg_im = Image.new("RGB", (1000, 200), (83, 83, 83))
-        bg_draw = ImageDraw.Draw(bg_im)
-        # create image with 5 200 x 200 px squares filled with colors from mono_cp
-
-        x0, y0, x1, y1 = 0, 0, 200, 200
-        for color in mono_cp:
-            bg_draw.rectangle((x0, y0, x1, y1), (color[0], color[1], color[2]))
-            x0 += 200
-            x1 += 200
-        bg_im.show()
+        if isinstance(mono_cps, dict):
+            print(f"Color palette:\nHLS: {mono_cps['h']}\nRGB: {mono_cps['r']}")
+            draw_color_palette(mono_cps['r'])
+        else:
+            print(f"Color palette: {mono_cps}")
+            draw_color_palette(mono_cps) # type: ignore
 
     except ValueError as e:
         print(e, file=sys.stdout)

--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -23,12 +23,11 @@ def interactive_flow():
         print(f"Color Format: {color_format}")
         # TODO: Fix main color and print HLS or RGB depending on user format input...geez!
         print(f"Main Color: {colorsys.hls_to_rgb(main_color[0], main_color[1], main_color[2])}")
-        if isinstance(mono_cps, dict):
+        if color_format == 'rh':
             print(f"Color palette:\nHLS: {mono_cps['h']}\nRGB: {mono_cps['r']}")
-            draw_color_palette(mono_cps['r'])
         else:
-            print(f"Color palette: {mono_cps}")
-            draw_color_palette(mono_cps) # type: ignore
+            print(f"Color palette: {mono_cps[color_format]}")
+        draw_color_palette(mono_cps['r'])
 
     except ValueError as e:
         print(e, file=sys.stdout)

--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -38,8 +38,6 @@ def interactive_flow():
             x0 += 200
             x1 += 200
         bg_im.show()
-        # mc_im = Image.new("RGB", (200, 200), int(main_color[0]))
-        # mc_im.show()
 
     except ValueError as e:
         print(e, file=sys.stdout)

--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -1,6 +1,10 @@
 import sys
-from cli_flow.utils import get_color_format, get_user_file, get_color_scheme
-from cpm_app.utils import get_color_from_img
+import os
+import colorsys
+from cpm_app.cli_flow.utils import get_color_format, get_user_file, get_color_scheme
+from PIL import Image, ImageDraw
+
+from cpm_app.utils import get_color_from_img, make_monochromatic_color_palette
 
 
 def interactive_flow():
@@ -12,6 +16,7 @@ def interactive_flow():
         color_scheme = get_color_scheme(color_schemes)
         color_format = get_color_format(color_formats)
         main_color = get_color_from_img(file_name)
+        mono_cp = make_monochromatic_color_palette(main_color, color_format)
         # TODO: Write function to generate color palette
             # generate_color_palette(cs: str, cf: str)
 
@@ -20,8 +25,21 @@ def interactive_flow():
         print(f"File: {file_name}")
         print(f"Color Scheme: {color_scheme}")
         print(f"Color Format: {color_format}")
-        print("Color palette: <rgb and/or hsl values> <colored squares>")
+        print(f"Main Color: {colorsys.hls_to_rgb(main_color[0], main_color[1], main_color[2])}")
+        print(f"Color palette: {mono_cp}")
 
+        bg_im = Image.new("RGB", (1000, 200), (83, 83, 83))
+        bg_draw = ImageDraw.Draw(bg_im)
+        # create image with 5 200 x 200 px squares filled with colors from mono_cp
+
+        x0, y0, x1, y1 = 0, 0, 200, 200
+        for color in mono_cp:
+            bg_draw.rectangle((x0, y0, x1, y1), (color[0], color[1], color[2]))
+            x0 += 200
+            x1 += 200
+        bg_im.show()
+        mc_im = Image.new("RGB", (200, 200), int(main_color[0]))
+        mc_im.show()
 
     except ValueError as e:
         print(e, file=sys.stdout)

--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -38,8 +38,8 @@ def interactive_flow():
             x0 += 200
             x1 += 200
         bg_im.show()
-        mc_im = Image.new("RGB", (200, 200), int(main_color[0]))
-        mc_im.show()
+        # mc_im = Image.new("RGB", (200, 200), int(main_color[0]))
+        # mc_im.show()
 
     except ValueError as e:
         print(e, file=sys.stdout)

--- a/cpm_app/main.py
+++ b/cpm_app/main.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from cli_flow.flow import interactive_flow
+from cpm_app.cli_flow.flow import interactive_flow
 from PIL import Image, UnidentifiedImageError
 
 

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -23,7 +23,7 @@ def get_color_from_img(file: str) -> Tuple[float, float, float]:
 ColorPalette = Dict[str, List[List[int]]]
 def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette:
     """
-    Returns a 5-step monochromatic color palette in HLS, RGB or both color formats
+    Returns a 5-step monochromatic color palette in HLS and RGB color formats
 
         Parameters:
             hls (Tuple[float, float, float]): A tuple of floats that represents an HLS color
@@ -81,11 +81,3 @@ def draw_color_palette(color_palette: List[List[int]]) -> None:
         x1 += 200
     bg_im.show()
     return None
-
-
-def main():
-    fp = input("Enter file path: ")
-    get_color_from_img(fp)
-
-if __name__ == "__main__":
-    main()

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -1,11 +1,10 @@
 import random
 import colorsys
-from typing import Union
-from dataclasses import dataclass
 from PIL import Image
+from typing import Union, List, Tuple
 
 
-def get_color_from_img(file: str) -> tuple[float, float, float]:
+def get_color_from_img(file: str) -> Tuple[float, float, float]:
     with Image.open(file) as im:
         im = im.convert("RGB")
         width, height = im.size
@@ -20,30 +19,73 @@ def get_color_from_img(file: str) -> tuple[float, float, float]:
     else:
         raise ValueError("Unsupported image mode or grayscale image detected. Only color images supported.")
 
-@dataclass
-class HLS:
-    hls_values: tuple[tuple[float, float, float],
-                        tuple[float, float, float],
-                        tuple[float, float, float],
-                        tuple[float, float, float],
-                        tuple[float, float, float]]
+# ColorPalette = List[Tuple[Union[float, int], Union[float, int], Union[float, int]]]
+ColorPalette = List[int]
 
-@dataclass
-class RGB:
-    rgb_values: tuple[tuple[int, int, int],
-                        tuple[int, int, int],
-                        tuple[int, int, int],
-                        tuple[int, int, int],
-                        tuple[int, int, int]]
+# Union[ColorPalette, dict[str, ColorPalette]
+def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette: #WIP
+    # Hue: Change 2 between 1 - 3 points
+    # Light: Increment each 8 to 13 points | Dark to Light == Low to High
+    # Sat: Vary +- 5 to 15 point of any 2
+    # holds 5 lists containing HLS values
 
-def make_monochromatic_color_palette(hls: tuple, **kwargs) -> Union[HLS, RGB, dict[HLS, RGB]]: #WIP
-    if True:
+    steps = 5
+    hls_cp = list()
+    h, l, s = hls
 
-        return HLS(((0.2,0.2,0.2),
-                    (0.2,0.2,0.2),
-                    (0.2,0.2,0.2),
-                    (0.2,0.2,0.2),
-                    (0.2,0.2,0.2)))
+    if format == "h":
+        new_h = h
+        new_l = 0
+        new_s = s
+
+        for i in range(steps):
+            print(f"LOOP -> h: {h}, l: {l}, s: {s} | new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
+            # Remember h, l and s are float type / a value between 0 and 1 (exclusive)
+            if i == 0 or i == 4:
+                variation = random.randrange(1, 3) # Fix for float
+                if h + variation > 100:
+                    new_h = h - variation
+                else:
+                    new_h = h + variation
+
+            if i == 1 or i == 3:
+                variation = random.randrange(5, 25) # Fix for float
+                if s + variation > 100:
+                    new_s = s - variation
+                else:
+                    new_s = s + variation
+
+            new_l += random.randrange(8, 35) # Fix for float
+
+            # convert back to RGB
+            r, g, b = colorsys.hls_to_rgb(new_h, new_l, new_s)
+
+            hls_cp.append([int(r), int(g), int(b)])
+
+        return hls_cp
+
+    # elif format == "r":
+    #     return [(2,2,2),
+    #             (2,2,2),
+    #             (2,2,2),
+    #             (2,2,2),
+    #             (2,2,2)]
+    # elif format == "":
+    #     formats = {
+    #         "hls_values": [(0.2,0.2,0.2),
+    #                     (0.2,0.2,0.2),
+    #                     (0.2,0.2,0.2),
+    #                     (0.2,0.2,0.2),
+    #                     (0.2,0.2,0.2)],
+    #         "rgb_values": [(2,2,2),
+    #                     (2,2,2),
+    #                     (2,2,2),
+    #                     (2,2,2),
+    #                     (2,2,2)]
+    #     }
+    #     return formats
+    else:
+        raise Exception("Unsupported color format")
 
 # Union[HLS, RGB, dict[HLS, RGB]]
 

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -22,6 +22,7 @@ def get_color_from_img(file: str) -> Tuple[float, float, float]:
 # ColorPalette = List[Tuple[Union[float, int], Union[float, int], Union[float, int]]]
 ColorPalette = List[int]
 
+# TODO: Write a docstring explaining this function and how we are calculcating steps
 # Union[ColorPalette, dict[str, ColorPalette]
 def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette: #WIP
     # Hue: Change 2 between 1 - 3 points
@@ -35,32 +36,36 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
 
     if format == "h":
         new_h = h
-        new_l = 0
+        new_l = 0.0
         new_s = s
 
+        SINGLE_UNIT = 0.00990099 # Equivalent to single unit (1) in the 0 - 100 range
+        RANGE_CEIL = 0.9999999999999999  # Equivalent to 100 in the 0 - 100 range
         for i in range(steps):
-            print(f"LOOP -> h: {h}, l: {l}, s: {s} | new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
-            # Remember h, l and s are float type / a value between 0 and 1 (exclusive)
+            # Remember h, l and s are float type fix below
             if i == 0 or i == 4:
-                variation = random.randrange(1, 3) # Fix for float
-                if h + variation > 100:
+                # Fix for float
+                variation = random.uniform(SINGLE_UNIT, (SINGLE_UNIT * 3.0)) # between 1 - 3 in in range of 0 - 100
+                if h + variation > RANGE_CEIL:
                     new_h = h - variation
                 else:
                     new_h = h + variation
 
             if i == 1 or i == 3:
-                variation = random.randrange(5, 25) # Fix for float
-                if s + variation > 100:
+                variation = random.uniform((SINGLE_UNIT * 5), (SINGLE_UNIT * 25)) # between 5 - 25 in in range of 0 - 100
+                if s + variation > RANGE_CEIL:
                     new_s = s - variation
                 else:
                     new_s = s + variation
 
-            new_l += random.randrange(8, 35) # Fix for float
+            new_l += random.uniform((SINGLE_UNIT * 8), (SINGLE_UNIT * 35)) # between 8 - 35 in in range of 0 - 100
 
+            print(f"LOOP -> h: {h}, l: {l}, s: {s} | new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
             # convert back to RGB
+            print(f"LOOP -> new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
             r, g, b = colorsys.hls_to_rgb(new_h, new_l, new_s)
 
-            hls_cp.append([int(r), int(g), int(b)])
+            hls_cp.append([int(r * 255), int(g * 255), int(b * 255)])
 
         return hls_cp
 

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -42,7 +42,6 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
         SINGLE_UNIT = 0.00990099 # Equivalent to single unit (1) in the 0 - 100 range
         RANGE_CEIL = 0.9999999999999999  # Equivalent to 100 in the 0 - 100 range
         for i in range(steps):
-            # Remember h, l and s are float type fix below
             if i == 0 or i == 4:
                 # Fix for float
                 variation = random.uniform(SINGLE_UNIT, (SINGLE_UNIT * 3.0)) # between 1 - 3 in in range of 0 - 100
@@ -52,15 +51,15 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
                     new_h = h + variation
 
             if i == 1 or i == 3:
-                variation = random.uniform((SINGLE_UNIT * 5), (SINGLE_UNIT * 25)) # between 5 - 25 in in range of 0 - 100
+                variation = random.uniform((SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0)) # between 5 - 25 in in range of 0 - 100
                 if s + variation > RANGE_CEIL:
                     new_s = s - variation
                 else:
                     new_s = s + variation
 
-            new_l += random.uniform((SINGLE_UNIT * 8), (SINGLE_UNIT * 35)) # between 8 - 35 in in range of 0 - 100
+            new_l += random.uniform((SINGLE_UNIT * 8.0), (SINGLE_UNIT * 20.0)) # between 8 - 20 in in range of 0 - 100
 
-            print(f"LOOP -> h: {h}, l: {l}, s: {s} | new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
+            # print(f"LOOP -> h: {h}, l: {l}, s: {s} | new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
             # convert back to RGB
             print(f"LOOP -> new_h: {new_h}, new_l: {new_l}, new_s: {new_s}")
             r, g, b = colorsys.hls_to_rgb(new_h, new_l, new_s)

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -1,7 +1,7 @@
 import random
 import colorsys
 from PIL import Image, ImageDraw
-from typing import List, Tuple, Dict, Union
+from typing import List, Tuple, Dict
 
 
 def get_color_from_img(file: str) -> Tuple[float, float, float]:
@@ -19,9 +19,9 @@ def get_color_from_img(file: str) -> Tuple[float, float, float]:
     else:
         raise ValueError("Unsupported image mode or grayscale image detected. Only color images supported.")
 
-# Union[ColorPalette, dict[str, ColorPalette]
+
 ColorPalette = Dict[str, List[List[int]]]
-def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> Union[ColorPalette, List[List[int]]]: #WIP
+def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette: #WIP
     """
     Returns a 5-step monochromatic color palette in HLS, RGB or both color formats
 
@@ -33,7 +33,6 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
             mono_cps (Dict[str, List[List[int]]]): A dict with a list containing lists of integers as the value for its keys
     """
     steps = 5
-    # mono_cp = list()
     mono_cps = {'h': [], 'r': []}
     h, l, s = hls
 
@@ -66,10 +65,6 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
             # convert back to RGB
             r, g, b = colorsys.hls_to_rgb(new_h, new_l, new_s)
             mono_cps['r'].append([int(r * 255), int(g * 255), int(b * 255)])
-
-        if format in ('r', 'h'):
-            return mono_cps['r']
-
         return mono_cps
     else:
         raise Exception("Unsupported color format")

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -40,11 +40,12 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
         new_s = s
 
         SINGLE_UNIT = 0.00990099 # Equivalent to single unit (1) in the 0 - 100 range
-        RANGE_CEIL = 0.9999999999999999  # Equivalent to 100 in the 0 - 100 range
+        SINGLE_HUE_UNIT = 0.0027777777 # Equivalent to single unit in the 0 - 360 range
+        RANGE_CEIL = 0.9999999999999999  # Equivalent to the max unit in the 0 - 100 range
         for i in range(steps):
             if i == 0 or i == 4:
-                # Fix for float
-                variation = random.uniform(SINGLE_UNIT, (SINGLE_UNIT * 3.0)) # between 1 - 3 in in range of 0 - 100
+                # Fix: Double check if hue range in HLS format is from 0 - 360
+                variation = random.uniform(SINGLE_HUE_UNIT, (SINGLE_HUE_UNIT * 3.0)) # between 1 - 3 in in range of 0 - 100
                 if h + variation > RANGE_CEIL:
                     new_h = h - variation
                 else:

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -21,7 +21,7 @@ def get_color_from_img(file: str) -> Tuple[float, float, float]:
 
 
 ColorPalette = Dict[str, List[List[int]]]
-def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette: #WIP
+def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette:
     """
     Returns a 5-step monochromatic color palette in HLS, RGB or both color formats
 

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -67,7 +67,7 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
             mono_cps['r'].append([int(r * 255), int(g * 255), int(b * 255)])
         return mono_cps
     else:
-        raise Exception("Unsupported color format")
+        raise ValueError("Unsupported color format")
 
 
 def draw_color_palette(color_palette: List[List[int]]) -> None:

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -1,5 +1,7 @@
 import random
 import colorsys
+from typing import Union
+from dataclasses import dataclass
 from PIL import Image
 
 
@@ -17,6 +19,35 @@ def get_color_from_img(file: str) -> tuple[float, float, float]:
         return (h, l, s)
     else:
         raise ValueError("Unsupported image mode or grayscale image detected. Only color images supported.")
+
+@dataclass
+class HLS:
+    hls_values: tuple[tuple[float, float, float],
+                        tuple[float, float, float],
+                        tuple[float, float, float],
+                        tuple[float, float, float],
+                        tuple[float, float, float]]
+
+@dataclass
+class RGB:
+    rgb_values: tuple[tuple[int, int, int],
+                        tuple[int, int, int],
+                        tuple[int, int, int],
+                        tuple[int, int, int],
+                        tuple[int, int, int]]
+
+def make_monochromatic_color_palette(hls: tuple, **kwargs) -> Union[HLS, RGB, dict[HLS, RGB]]: #WIP
+    if True:
+
+        return HLS(((0.2,0.2,0.2),
+                    (0.2,0.2,0.2),
+                    (0.2,0.2,0.2),
+                    (0.2,0.2,0.2),
+                    (0.2,0.2,0.2)))
+
+# Union[HLS, RGB, dict[HLS, RGB]]
+
+
 
 
 def main():

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -20,7 +20,7 @@ def get_color_from_img(file: str) -> Tuple[float, float, float]:
         raise ValueError("Unsupported image mode or grayscale image detected. Only color images supported.")
 
 # ColorPalette = List[Tuple[Union[float, int], Union[float, int], Union[float, int]]]
-ColorPalette = List[int]
+ColorPalette = List[List[int]]
 
 # TODO: Write a docstring explaining this function and how we are calculcating steps
 # Union[ColorPalette, dict[str, ColorPalette]
@@ -31,7 +31,7 @@ def make_monochromatic_color_palette(hls: Tuple[float, float, float], format: st
     # holds 5 lists containing HLS values
 
     steps = 5
-    hls_cp = list()
+    hls_cp: ColorPalette = list()
     h, l, s = hls
 
     if format == "h":

--- a/tests/test_MakeMonoColorPalette.py
+++ b/tests/test_MakeMonoColorPalette.py
@@ -3,7 +3,6 @@ from cpm_app.utils import make_monochromatic_color_palette
 
 TEST_HLS_COLOR = (0.37, 0.27, 0.20)
 
-# test for return value in single format rgb
 def test_palette_in_rgb():
     cp = make_monochromatic_color_palette(TEST_HLS_COLOR, 'r')
     assert len(cp) == 2
@@ -12,7 +11,6 @@ def test_palette_in_rgb():
     assert isinstance(cp['r'][0][0], int)
 
 
-# test for return value in single format hls (should still return in rgb)
 def test_palette_in_hls():
     cp = make_monochromatic_color_palette(TEST_HLS_COLOR, 'h')
     assert len(cp) == 2
@@ -20,7 +18,7 @@ def test_palette_in_hls():
     assert len(cp['h'][0]) == 3
     assert isinstance(cp['h'][0][0], int)
 
-# test for return value in both formats dict with rgb and hls
+
 def test_palette_in_both_formats():
     cp = make_monochromatic_color_palette(TEST_HLS_COLOR, 'rh')
     assert len(cp) == 2
@@ -30,6 +28,7 @@ def test_palette_in_both_formats():
     assert len(cp['r'][0]) == 3
     assert isinstance(cp['h'][0][0], int)
     assert isinstance(cp['r'][0][0], int)
+
 
 def test_invalid_color_format():
     with pytest.raises(ValueError) as excinfo:

--- a/tests/test_makeMonoColorPalette.py
+++ b/tests/test_makeMonoColorPalette.py
@@ -1,5 +1,4 @@
 import pytest
-import sys
 from cpm_app.utils import make_monochromatic_color_palette
 
 TEST_HLS_COLOR = (0.37, 0.27, 0.20)

--- a/tests/test_makeMonoColorPalette.py
+++ b/tests/test_makeMonoColorPalette.py
@@ -1,0 +1,31 @@
+from cpm_app.utils import make_monochromatic_color_palette
+
+TEST_HLS_COLOR = (0.37, 0.27, 0.20)
+
+# test for return value in single format rgb
+def test_palette_in_rgb():
+    cp = make_monochromatic_color_palette(TEST_HLS_COLOR, 'r')
+    assert len(cp) == 2
+    assert len(cp['r']) == 5
+    assert len(cp['r'][0]) == 3
+    assert isinstance(cp['r'][0][0], int)
+
+
+# test for return value in single format hls (should still return in rgb)
+def test_palette_in_hls():
+    cp = make_monochromatic_color_palette(TEST_HLS_COLOR, 'h')
+    assert len(cp) == 2
+    assert len(cp['h']) == 5
+    assert len(cp['h'][0]) == 3
+    assert isinstance(cp['h'][0][0], int)
+
+# test for return value in both formats dict with rgb and hls
+def test_palette_in_both_formats():
+    cp = make_monochromatic_color_palette(TEST_HLS_COLOR, 'rh')
+    assert len(cp) == 2
+    assert len(cp['h']) == 5
+    assert len(cp['r']) == 5
+    assert len(cp['h'][0]) == 3
+    assert len(cp['r'][0]) == 3
+    assert isinstance(cp['h'][0][0], int)
+    assert isinstance(cp['r'][0][0], int)

--- a/tests/test_makeMonoColorPalette.py
+++ b/tests/test_makeMonoColorPalette.py
@@ -1,3 +1,5 @@
+import pytest
+import sys
 from cpm_app.utils import make_monochromatic_color_palette
 
 TEST_HLS_COLOR = (0.37, 0.27, 0.20)
@@ -29,3 +31,8 @@ def test_palette_in_both_formats():
     assert len(cp['r'][0]) == 3
     assert isinstance(cp['h'][0][0], int)
     assert isinstance(cp['r'][0][0], int)
+
+def test_invalid_color_format():
+    with pytest.raises(ValueError) as excinfo:
+        make_monochromatic_color_palette(TEST_HLS_COLOR, '')
+    assert "Unsupported color format" in str(excinfo.value)


### PR DESCRIPTION
# Description
I wrote the logic for generating a 5-step monochromatic color palette in the function `make_monochromatic_color_palette`. There are two reasons why we are handling colors as floating-point:

1- `colorsys` accepts floating-point values for color format conversion.

2- To avoid unnecessary back-and-forth between converting values and color formats, I decided to generate the palette using floating-point values and perform the conversions at the end as needed.

To provide more context on the number type and color format conversions mentioned above, I also wrote the function `draw_color_palette`, which requires colors in RGB format and integer values for the following reasons:

1- `PIL.Image.new` does not accept HLS, so I use RGB to render the color palette.

2- The `rectangle` method from the `PIL.Image.Draw` class only accepts integer values, not floating-point numbers.

---<b>ASIDE</b>---
`draw_color_palette` is the only way I know and have to visually render the color palette. The future goal is to find the appropriate tool to render the color palette in the command line interface. 

Relevant files:
- `/cpm_app/utils.py`
- `/cpm_app/cli_flow/flow.py`
- `cpm/tests/test_MakeMonoColorPalette.py`

## Fixes 
https://github.com/tomrod10/cpm/issues/7

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added unit tests in `cpm/tests/test_MakeMonoColorPalette.py`

## Screenshots
Color palettes:
![Screenshot from 2024-12-20 14-14-26](https://github.com/user-attachments/assets/5cfed61c-718f-4127-9c8e-008195ae0e89)

Image used:
![Screenshot from 2024-08-11 21-34-28](https://github.com/user-attachments/assets/6a1315b3-8eda-4aea-8220-98b1c0a74e5b)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes