### PR TITLE
[Core] Write logic to generate analogous color palette

### DIFF
--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -1,33 +1,41 @@
 import sys
 from cpm_app.cli_flow.utils import get_color_format, get_user_file, get_color_scheme
-
-from cpm_app.utils import get_color_from_img, make_mono_color_palette, process_and_print_res
+from cpm_app.utils import get_color_from_img, make_mono_color_palette, make_alog_color_palette,process_and_print_res
 
 
 def interactive_flow() -> None:
     valid_exts = [".jpg", ".jpeg", ".png"]
     color_schemes = ["mono", "alog", "comp", "scomp"]
     color_formats = ["r", "h", ""]
-    try:
-        file_name = get_user_file(valid_exts)
-        color_scheme = get_color_scheme(color_schemes)
-        color_format = get_color_format(color_formats)
-        main_color = get_color_from_img(file_name)
-        color_palette = {}
 
-        match color_scheme:
-            case "mono":
-                color_palette = make_mono_color_palette(main_color, color_format)
-            case _:
-                print("Default case. This feature is still a WIP")
-                raise ValueError("Invalid color scheme. Try again!")
+    while True:
+        try:
+            file_name = get_user_file(valid_exts)
+            color_scheme = get_color_scheme(color_schemes)
+            color_format = get_color_format(color_formats)
+            main_color = get_color_from_img(file_name)
+            color_palette = {} # TODO: Rename to color_palettes
 
-        process_and_print_res(file_name, color_scheme, color_format, main_color, color_palette)
+            match color_scheme:
+                case "mono":
+                    color_palette = make_mono_color_palette(main_color, color_format)
+                case "alog":
+                    color_palette = make_alog_color_palette(main_color, color_format)
+                case _:
+                    print("Default case. This feature is still a WIP")
+                    raise ValueError("Invalid color scheme. Try again!")
 
-    except ValueError as e:
-        print(e, file=sys.stdout)
-    except KeyboardInterrupt:
-        sys.exit("\nStay creative, bye!")
+            process_and_print_res(file_name, color_scheme, color_format, main_color, color_palette)
+
+            retry = input("Would you like to generate another color palette? (y/n): ")
+            if retry == "y":
+                continue
+            else:
+                sys.exit("Stay creative, bye!")
+        except ValueError as e:
+            print(e, file=sys.stdout)
+        except KeyboardInterrupt:
+            sys.exit("\nStay creative, bye!")
     return None
 
 if __name__ == "__main__":

--- a/cpm_app/main.py
+++ b/cpm_app/main.py
@@ -5,20 +5,7 @@ from PIL import Image, UnidentifiedImageError
 
 
 def main():
-    while True:
-        # if user invokes CPM interactive flow
-        interactive_flow()
-
-        # if user sends direct command
-        # flow.direct()
-
-        # TODO: move this to only be accesible from the interactive flow
-        retry = input("Would you like to generate another color palette? (y/n): ")
-        if retry == "y":
-            continue
-        else:
-            sys.exit("Stay creative, bye!")
-
+    interactive_flow()
 
 
 if __name__ == "__main__":

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -37,7 +37,7 @@ def make_mono_color_palette(hls: Tuple[float, float, float], format: str) -> Col
             format (string): A string representing color format to return to user. 'h' for HLS, 'r' for RGB and None or 'b' for both HLS and RGB
 
         Returns:
-            mono_cps (Dict[str, List[List[int]]]): A dict with a list containing lists of integers as the value for its keys
+            color_palette (Dict[str, List[List[int]]]): A dict with a list containing lists of integers as the value for its keys
     """
     color_palette = {'h': [], 'r': []}
     h, l, s = hls
@@ -74,6 +74,16 @@ def make_mono_color_palette(hls: Tuple[float, float, float], format: str) -> Col
 
 
 def make_alog_color_palette(hls: Tuple[float, float, float], format: str) -> ColorPalette:
+    """
+    Returns a 5-step analogous color palette in HLS and RGB color formats
+
+        Parameters:
+            hls (Tuple[float, float, float]): A tuple of floats that represents an HLS color
+            format (string): A string representing color format to return to user. 'h' for HLS, 'r' for RGB and None or 'b' for both HLS and RGB
+
+        Returns:
+            color_palette (Dict[str, List[List[int]]]): A dict with a list containing lists of integers as the value for its keys
+    """
     color_palette = {'h': [], 'r': []}
     h, l, s = hls
 


### PR DESCRIPTION
# Description
Wrote logic to generate analogous color palette in `generate_analogous_color_palette` function inside `/cpm_app/utils.py`.

Additionally, cleaned up the code in `main.py` and `flow.py` to make it easier to understand an develop.

Relevant files:
- `/cpm_app/utils.py`
- `/cpm_app/main.py`
- `/cpm_app/cli_flow/flow.py`

## Fixes 
https://github.com/tomrod10/cpm/issues/14

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (changes do not affect external behavior)

# How Has This Been Tested?

- [x] Manually tested with the same image used for testing the monochromatic color palette generation 
- [x] No tests needed

## Screenshots
![Screenshot from 2025-02-12 20-18-28](https://github.com/user-attachments/assets/b89ae71c-b1c9-410c-80a1-87d7b6bd2445)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes