### PR TITLE
[Core] Implement complementary color palette logic

### DIFF
--- a/cpm_app/cli_flow/flow.py
+++ b/cpm_app/cli_flow/flow.py
@@ -8,6 +8,7 @@ from cpm_app.utils import (
     get_color_from_img,
     make_mono_color_palette,
     make_alog_color_palette,
+    make_comp_color_palette,
     process_and_print_res,
 )
 
@@ -32,6 +33,10 @@ def interactive_flow() -> None:
                     )
                 case "alog":
                     color_palette = make_alog_color_palette(
+                        main_color, color_format
+                    )
+                case "comp":
+                    color_palette = make_comp_color_palette(
                         main_color, color_format
                     )
                 case _:

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -211,7 +211,7 @@ def find_adjacent_hue(hue: float):
         single_h_unit (float): Single value unit in color wheel (1˚) as a float
 
     Returns:
-        hue (float): Hue value in HLS format
+        adj_hue (float): Adjacent hue value in HLS format
     """
     shift = SINGLE_HUE_UNIT * random.uniform(5.0, 20.0)
     adj_hue = hue + shift
@@ -227,6 +227,9 @@ def find_comp_hue(hue: float):
 
     Parameters:
         hue (float): Hue value in HLS format
+
+    Returns:
+        comp_hue (float): Complementary hue value in HLS format
     """
     shift = SINGLE_HUE_UNIT * 180.0
     comp_hue = hue + shift
@@ -243,6 +246,9 @@ def normalize_hue(hue: float, shift: float):
     Parameters:
         hue (float): Hue value in HLS format
         shift (float): Amount moving in the color wheel
+    
+    Returns:
+        hue (float): Hue value in HLS format
     """
     diff = RANGE_CEIL - hue
     shift = abs(shift - diff)
@@ -256,6 +262,9 @@ def find_next_sat(sat: float):
 
     Parameters:
         sat (float): Saturation value in HLS format
+    
+    Returns:
+        new_s (float): Shifted saturation value in HLS format
     """
     shift = random.uniform((SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0))
     new_s = sat + shift
@@ -271,6 +280,9 @@ def normalize_sat(sat: float, shift: float):
     Parameters:
         sat (float): Saturation value in HLS format
         shift (float): Amount moving in the color wheel
+
+    Returns:
+        sat (float): Normalized saturation value in HLS format
     """
     diff = RANGE_CEIL - sat
     shift = abs(shift - diff)

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Dict
 
 
 # HLS units and range
-SINGLE_UNIT = 0.00990099  # Equivalent to single unit in the 0 - 100 range
+SINGLE_UNIT = 0.00990099  # Equivalent to single unit in the 0 - 100 range for L and S in HLS
 SINGLE_HUE_UNIT = 0.0027777777  # Equivalent to single unit in the 0 - 360 range
 RANGE_CEIL = (
     0.9999999999999999  # Equivalent to the max value in our number range
@@ -162,6 +162,106 @@ def make_alog_color_palette(
     else:
         raise ValueError("Unsupported color format")
 
+
+def make_comp_color_palette(
+    hls: Tuple[float, float, float], format: str
+) -> ColorPalette:
+    # init
+    h, l, s = hls
+    color_palette = {"h": [], "r": []}
+
+    if format in ("r", "h", "rh"):
+        new_h = h
+        new_l = l
+        new_s = s
+        comp_colors = []
+
+        for i in range(STEPS):
+            # append hue value
+            color_palette["h"].append(
+                [new_h, new_l, new_s]
+            )
+
+            # Calculate complementary hue and append
+            comp_h = find_comp_hue(new_h)
+            comp_colors.append(
+                [comp_h , new_l, new_s]
+            )
+
+            # Get new hue to then get its complement in the next loop
+            new_h = find_adjacent_hue(new_h)
+
+            if i in (1, 3):
+                variation = random.uniform(
+                    (SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0)
+                )
+                if s + variation > RANGE_CEIL:
+                    new_s = s - variation
+                else:
+                    new_s = s + variation
+
+            new_l += random.uniform((SINGLE_UNIT * 8.0), (SINGLE_UNIT * 20.0))
+        
+        color_palette["h"] += comp_colors[::-1]
+        print("-----------", color_palette)
+        color_palette = convert_to_valid_color_palettes(color_palette)
+        return color_palette
+    else:
+        raise ValueError("Unsupported color format")
+
+# This function should only calculate the next main hue. Create separate function to get complementary color
+def find_adjacent_hue(hue: float):
+    """
+    Calculates the degree shift in the color wheel as a floating number and applies it to the passed hue and returns it
+
+    Parameters:
+        hue (float): Hue value in HLS format
+        ceil (float): Max value in color wheel (360˚) as a float
+        single_h_unit (float): Single value unit in color wheel (1˚) as a float
+
+    Returns:
+        hue (float): Hue value in HLS format
+    """
+    shift = SINGLE_HUE_UNIT * random.uniform(5.0, 20.0)
+    adj_hue = hue + shift
+
+    if adj_hue > RANGE_CEIL:
+        return normalize_hue(hue, shift)
+    return adj_hue
+
+def find_comp_hue(hue: float):
+    shift =  SINGLE_HUE_UNIT * 180.0
+    comp_hue = hue + shift
+    
+    if comp_hue > RANGE_CEIL:
+        return normalize_hue(hue, shift)
+    return comp_hue
+
+def normalize_hue(hue: float, shift: float):
+    diff = RANGE_CEIL - hue
+    shift -= diff
+    hue = 0.0 + shift
+    return hue
+
+def normalize_light_and_sat(light, sat): ...
+
+def convert_to_valid_color_palettes(color_palette: ColorPalette):
+    hls, rgb = color_palette.values()
+    for (h, l, s) in hls:
+        # convert to rgb non decimal
+        r, g, b = colorsys.hls_to_rgb(h, l, s)
+        rgb.append([
+            int(r * 255), int(g * 255), int(b * 255)
+        ])
+
+        #TODO: convert to hex value
+        
+        # convert to hls non decimal
+        h = int(h * 360)
+        l = int(l * 100)
+        s = int(s * 100)
+
+    return {"h": hls, "r": rgb}
 
 def draw_color_palette(color_palette: List[List[int]]) -> None:
     bg_im = Image.new("RGB", (1000, 200), (83, 83, 83))

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -162,7 +162,7 @@ def make_alog_color_palette(
     else:
         raise ValueError("Unsupported color format")
 
-
+# TODO: Add documentation
 def make_comp_color_palette(
     hls: Tuple[float, float, float], format: str
 ) -> ColorPalette:
@@ -203,7 +203,7 @@ def make_comp_color_palette(
 
 def find_adjacent_hue(hue: float):
     """
-    Calculates the degree shift in the color wheel as a floating number and applies it to the passed hue and returns it
+    Calculates the degree shift in the color wheel as a floating number and applies it to the passed hue
 
     Parameters:
         hue (float): Hue value in HLS format
@@ -222,6 +222,12 @@ def find_adjacent_hue(hue: float):
 
 
 def find_comp_hue(hue: float):
+    """
+    Finds the complementary hue and checks that it is within bounds
+
+    Parameters:
+        hue (float): Hue value in HLS format
+    """
     shift = SINGLE_HUE_UNIT * 180.0
     comp_hue = hue + shift
 
@@ -231,6 +237,13 @@ def find_comp_hue(hue: float):
 
 
 def normalize_hue(hue: float, shift: float):
+    """
+    Returns the correct color within the bounds of a color wheel 0˚ - 360˚ (0 - 0.9~ in floating number)
+
+    Parameters:
+        hue (float): Hue value in HLS format
+        shift (float): Amount moving in the color wheel
+    """
     diff = RANGE_CEIL - hue
     shift = abs(shift - diff)
     hue = 0.0 + shift
@@ -238,6 +251,12 @@ def normalize_hue(hue: float, shift: float):
 
 
 def find_next_sat(sat: float):
+    """
+    Finds the next saturation value and checks that it is within bounds
+
+    Parameters:
+        sat (float): Saturation value in HLS format
+    """
     shift = random.uniform((SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0))
     new_s = sat + shift
     if new_s > RANGE_CEIL:
@@ -246,12 +265,19 @@ def find_next_sat(sat: float):
 
 
 def normalize_sat(sat: float, shift: float):
+    """
+    Returns the correct saturation within the bounds of HLS format 0 - 100 (0 - 0.9~ in floating number)
+
+    Parameters:
+        sat (float): Saturation value in HLS format
+        shift (float): Amount moving in the color wheel
+    """
     diff = RANGE_CEIL - sat
     shift = abs(shift - diff)
     sat = 0.0 + shift
     return sat
 
-
+# TODO: Add documentation
 def convert_to_valid_color_palettes(color_palette: ColorPalette):
     hls, rgb = color_palette.values()
     for h, l, s in hls:
@@ -261,7 +287,7 @@ def convert_to_valid_color_palettes(color_palette: ColorPalette):
 
         # TODO: convert to hex value
 
-        # convert to hls non decimal
+        # TODO: convert to hls non decimal
         l = int(l * 100)
         s = int(s * 100)
 

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -207,8 +207,6 @@ def find_adjacent_hue(hue: float):
 
     Parameters:
         hue (float): Hue value in HLS format
-        ceil (float): Max value in color wheel (360˚) as a float
-        single_h_unit (float): Single value unit in color wheel (1˚) as a float
 
     Returns:
         adj_hue (float): Adjacent hue value in HLS format
@@ -217,7 +215,7 @@ def find_adjacent_hue(hue: float):
     adj_hue = hue + shift
 
     if adj_hue > RANGE_CEIL:
-        return normalize_hue(hue, shift)
+        return normalize_hls(hue, shift)
     return adj_hue
 
 
@@ -235,25 +233,25 @@ def find_comp_hue(hue: float):
     comp_hue = hue + shift
 
     if comp_hue > RANGE_CEIL:
-        return normalize_hue(hue, shift)
+        return normalize_hls(hue, shift)
     return comp_hue
 
 
-def normalize_hue(hue: float, shift: float):
+def normalize_hls(val: float, shift: float):
     """
     Returns the correct color within the bounds of a color wheel 0˚ - 360˚ (0 - 0.9~ in floating number)
 
     Parameters:
-        hue (float): Hue value in HLS format
+        val (float): val value in HLS format (hue or saturation)
         shift (float): Amount moving in the color wheel
     
     Returns:
-        hue (float): Hue value in HLS format
+        val (float): val value in HLS format
     """
-    diff = RANGE_CEIL - hue
+    diff = RANGE_CEIL - val
     shift = abs(shift - diff)
-    hue = 0.0 + shift
-    return hue
+    val = 0.0 + shift
+    return val
 
 
 def find_next_sat(sat: float):
@@ -269,25 +267,9 @@ def find_next_sat(sat: float):
     shift = random.uniform((SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0))
     new_s = sat + shift
     if new_s > RANGE_CEIL:
-        return normalize_sat(sat, shift)
+        return normalize_hls(sat, shift)
     return new_s
 
-
-def normalize_sat(sat: float, shift: float):
-    """
-    Returns the correct saturation within the bounds of HLS format 0 - 100 (0 - 0.9~ in floating number)
-
-    Parameters:
-        sat (float): Saturation value in HLS format
-        shift (float): Amount moving in the color wheel
-
-    Returns:
-        sat (float): Normalized saturation value in HLS format
-    """
-    diff = RANGE_CEIL - sat
-    shift = abs(shift - diff)
-    sat = 0.0 + shift
-    return sat
 
 # TODO: Add documentation
 def convert_to_valid_color_palettes(color_palette: ColorPalette):

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -178,15 +178,12 @@ def make_comp_color_palette(
 
         for i in range(STEPS):
             # append hue value
-            color_palette["h"].append(
-                [new_h, new_l, new_s]
-            )
+            color_palette["h"].append([new_h, new_l, new_s])
 
-            # Calculate complementary hue and append
-            comp_h = find_comp_hue(new_h)
-            comp_colors.append(
-                [comp_h , new_l, new_s]
-            )
+            if i in (0, 2):
+                # Calculate complementary hue and append
+                comp_h = find_comp_hue(new_h)
+                comp_colors.append([comp_h, new_l, new_s])
 
             # Get new hue to then get its complement in the next loop
             new_h = find_adjacent_hue(new_h)
@@ -201,15 +198,15 @@ def make_comp_color_palette(
                     new_s = s + variation
 
             new_l += random.uniform((SINGLE_UNIT * 8.0), (SINGLE_UNIT * 20.0))
-        
-        color_palette["h"] += comp_colors[::-1]
-        print("-----------", color_palette)
+
+        color_palette["h"][0:3] += comp_colors
+        print("-----------", len(color_palette["h"]))
         color_palette = convert_to_valid_color_palettes(color_palette)
         return color_palette
     else:
         raise ValueError("Unsupported color format")
 
-# This function should only calculate the next main hue. Create separate function to get complementary color
+
 def find_adjacent_hue(hue: float):
     """
     Calculates the degree shift in the color wheel as a floating number and applies it to the passed hue and returns it
@@ -229,39 +226,53 @@ def find_adjacent_hue(hue: float):
         return normalize_hue(hue, shift)
     return adj_hue
 
+
 def find_comp_hue(hue: float):
-    shift =  SINGLE_HUE_UNIT * 180.0
+    shift = SINGLE_HUE_UNIT * 180.0
     comp_hue = hue + shift
-    
+
     if comp_hue > RANGE_CEIL:
         return normalize_hue(hue, shift)
     return comp_hue
 
+
 def normalize_hue(hue: float, shift: float):
     diff = RANGE_CEIL - hue
-    shift -= diff
+    shift = abs(shift - diff)
     hue = 0.0 + shift
     return hue
 
-def normalize_light_and_sat(light, sat): ...
+
+def find_next_sat(sat: float):
+    shift = random.uniform((SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0))
+    new_sat = sat + shift
+    if new_sat > RANGE_CEIL:
+        return normalize_sat(sat, shift)
+    return new_sat
+
+
+def normalize_sat(sat: float, shift: float):
+    diff = RANGE_CEIL - sat
+    shift = abs(shift - diff)
+    sat = 0.0 + shift
+    return sat
+
 
 def convert_to_valid_color_palettes(color_palette: ColorPalette):
     hls, rgb = color_palette.values()
-    for (h, l, s) in hls:
+    for h, l, s in hls:
         # convert to rgb non decimal
         r, g, b = colorsys.hls_to_rgb(h, l, s)
-        rgb.append([
-            int(r * 255), int(g * 255), int(b * 255)
-        ])
+        rgb.append([int(r * 255), int(g * 255), int(b * 255)])
 
-        #TODO: convert to hex value
-        
+        # TODO: convert to hex value
+
         # convert to hls non decimal
-        h = int(h * 360)
         l = int(l * 100)
         s = int(s * 100)
 
     return {"h": hls, "r": rgb}
+
 
 def draw_color_palette(color_palette: List[List[int]]) -> None:
     bg_im = Image.new("RGB", (1000, 200), (83, 83, 83))

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -174,27 +174,27 @@ def make_comp_color_palette(
         new_h = h
         new_l = l
         new_s = s
-        comp_colors = []
 
-        for i in range(STEPS):
-            # append hue value
-            color_palette["h"].append([new_h, new_l, new_s])
+        main_clr = []
+        comp_clr = []
+        i = 0
+        while len(main_clr) + len(comp_clr) < 5:
+            main_clr.append([new_h, new_l, new_s])
 
             if i in (0, 2):
                 # Calculate complementary hue and append
                 comp_h = find_comp_hue(new_h)
-                comp_colors.append([comp_h, new_l, new_s])
+                comp_clr.append([comp_h, new_l, new_s])
 
-            # Get new hue to then get its complement in the next loop
             new_h = find_adjacent_hue(new_h)
 
             if i in (1, 3):
                 new_s = find_next_sat(s)
 
             new_l += random.uniform((SINGLE_UNIT * 8.0), (SINGLE_UNIT * 20.0))
+            i += 1
 
-        color_palette["h"][0:3] += comp_colors
-        print("-----------", len(color_palette["h"]))
+        color_palette["h"] = main_clr[::-1] + comp_clr
         color_palette = convert_to_valid_color_palettes(color_palette)
         return color_palette
     else:

--- a/cpm_app/utils.py
+++ b/cpm_app/utils.py
@@ -189,13 +189,7 @@ def make_comp_color_palette(
             new_h = find_adjacent_hue(new_h)
 
             if i in (1, 3):
-                variation = random.uniform(
-                    (SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0)
-                )
-                if s + variation > RANGE_CEIL:
-                    new_s = s - variation
-                else:
-                    new_s = s + variation
+                new_s = find_next_sat(s)
 
             new_l += random.uniform((SINGLE_UNIT * 8.0), (SINGLE_UNIT * 20.0))
 
@@ -245,10 +239,10 @@ def normalize_hue(hue: float, shift: float):
 
 def find_next_sat(sat: float):
     shift = random.uniform((SINGLE_UNIT * 5.0), (SINGLE_UNIT * 25.0))
-    new_sat = sat + shift
-    if new_sat > RANGE_CEIL:
+    new_s = sat + shift
+    if new_s > RANGE_CEIL:
         return normalize_sat(sat, shift)
-    return new_sat
+    return new_s
 
 
 def normalize_sat(sat: float, shift: float):


### PR DESCRIPTION
# Description
Wrote logic to generate complementary color palette in `make_comp_color_palette` function inside `/cpm_app/utils.py`.

Added the following util functions to make code clearer and easier to work with:
- `find_adjacent_hue`
- `find_comp_hue`
- `normalize_hue`
- `find_next_sat`
- `convert_to_valid_color_palettes` (WIP - Will work on separate issue)

Relevant files:
- `/cpm_app/utils.py`
- `/cpm_app/cli_flow/flow.py`

## Fixes 
https://github.com/tomrod10/cpm/issues/19

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor (changes do not affect external behavior)

# How Has This Been Tested?

- [x] Manually tested with the same image used for other color scheme options 
- [x] No tests needed

## Screenshots
TBD


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes